### PR TITLE
Deprecate `getOrderTransactionDetails`, add `getOrderTransactionData` as replacement

### DIFF
--- a/src/Api/Request/Orders.php
+++ b/src/Api/Request/Orders.php
@@ -66,6 +66,18 @@ class Orders extends Client implements OrdersInterface
     /**
      * @inheritDoc
      */
+    public function getOrderTransactionData(int $orderId): Response
+    {
+        return new Response(
+            $this->post('getOrderTransactionData', [
+                'order_id' => $orderId,
+            ])
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function getOrdersByEmail(string $email): Response
     {
         return new Response(

--- a/src/Api/Request/OrdersInterface.php
+++ b/src/Api/Request/OrdersInterface.php
@@ -32,10 +32,19 @@ interface OrdersInterface
     public function getOrders(array $data): Response;
 
     /**
+     * @deprecated 0.6.0
+     * @use \Baselinker\Api\Request\OrdersInterface::getOrderTransactionData
+     *
      * @param int $orderId
      * @return \Baselinker\Api\Response\Response
      */
     public function getOrderTransactionDetails(int $orderId): Response;
+
+    /**
+     * @param int $orderId
+     * @return \Baselinker\Api\Response\Response
+     */
+    public function getOrderTransactionData(int $orderId): Response;
 
     /**
      * @param string $email


### PR DESCRIPTION
`getOrderTransactionDetails` has been replaced by `getOrderTransactionData` in the API