### PR TITLE
Allow GuzzleHttp/Client to be easily mocked for tests

### DIFF
--- a/src/Api/Client.php
+++ b/src/Api/Client.php
@@ -24,13 +24,19 @@ class Client
      * @var \GuzzleHttp\ClientInterface
      */
     private $client;
-
+	
     /**
      * @param \Baselinker\Config $config
+     * @param \GuzzleHttp\ClientInterface|null $client
      */
-    public function __construct(Config $config)
+    public function __construct(Config $config, ?ClientInterface $client = null)
     {
         $this->config = $config;
+        $this->client = $client ?: new GuzzleClient([
+            'base_uri' => $this->getApiUrl(),
+            RequestOptions::CONNECT_TIMEOUT => 10,
+            RequestOptions::TIMEOUT => 30,
+        ]);
     }
 
     /**
@@ -40,7 +46,7 @@ class Client
      */
     protected function post(string $function, array $parameters = []): ResponseInterface
     {
-        return $this->client()->post('connector.php', [
+        return $this->client->post('connector.php', [
             RequestOptions::HEADERS => [
                 'X-BLToken' => $this->config->getToken(),
             ],
@@ -49,22 +55,6 @@ class Client
                 'parameters' => json_encode($parameters),
             ],
         ]);
-    }
-
-    /**
-     * @return \GuzzleHttp\ClientInterface
-     */
-    protected function client(): ClientInterface
-    {
-        if (!$this->client) {
-            $this->client = new GuzzleClient([
-                'base_uri' => $this->getApiUrl(),
-                RequestOptions::CONNECT_TIMEOUT => 10,
-                RequestOptions::TIMEOUT => 30,
-            ]);
-        }
-
-        return $this->client;
     }
 
     /**

--- a/src/Api/Request/BaselinkerConnect.php
+++ b/src/Api/Request/BaselinkerConnect.php
@@ -4,9 +4,21 @@ namespace Baselinker\Api\Request;
 
 use Baselinker\Api\Client;
 use Baselinker\Api\Response\Response;
+use Baselinker\Config;
+use GuzzleHttp\ClientInterface;
 
 class BaselinkerConnect extends Client implements BaselinkerConnectInterface
 {
+ 
+    /**
+     * @param \Baselinker\Config $config
+     * @param \GuzzleHttp\ClientInterface|null $client
+     */
+    public function __construct(Config $config, ?ClientInterface $client = null)
+    {
+        parent::__construct($config, $client);
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/Api/Request/CourierShipments.php
+++ b/src/Api/Request/CourierShipments.php
@@ -4,9 +4,21 @@ namespace Baselinker\Api\Request;
 
 use Baselinker\Api\Client;
 use Baselinker\Api\Response\Response;
+use Baselinker\Config;
+use GuzzleHttp\ClientInterface;
 
 class CourierShipments extends Client implements CourierShipmentsInterface
 {
+ 
+    /**
+     * @param \Baselinker\Config $config
+     * @param \GuzzleHttp\ClientInterface|null $client
+     */
+    public function __construct(Config $config, ?ClientInterface $client = null)
+    {
+        parent::__construct($config, $client);
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/Api/Request/ExternalStorages.php
+++ b/src/Api/Request/ExternalStorages.php
@@ -4,9 +4,20 @@ namespace Baselinker\Api\Request;
 
 use Baselinker\Api\Client;
 use Baselinker\Api\Response\Response;
+use Baselinker\Config;
+use GuzzleHttp\ClientInterface;
 
 class ExternalStorages extends Client implements ExternalStoragesInterface
 {
+ 
+    /**
+     * @param \Baselinker\Config $config
+     * @param \GuzzleHttp\ClientInterface|null $client
+     */
+    public function __construct(Config $config, ?ClientInterface $client = null)
+    {
+        parent::__construct($config, $client);
+    }
 
     /**
      * @inheritDoc

--- a/src/Api/Request/OrderReturns.php
+++ b/src/Api/Request/OrderReturns.php
@@ -4,9 +4,21 @@ namespace Baselinker\Api\Request;
 
 use Baselinker\Api\Client;
 use Baselinker\Api\Response\Response;
+use Baselinker\Config;
+use GuzzleHttp\ClientInterface;
 
 class OrderReturns extends Client implements OrderReturnsInterface
 {
+ 
+    /**
+     * @param \Baselinker\Config $config
+     * @param \GuzzleHttp\ClientInterface|null $client
+     */
+    public function __construct(Config $config, ?ClientInterface $client = null)
+    {
+        parent::__construct($config, $client);
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/Api/Request/Orders.php
+++ b/src/Api/Request/Orders.php
@@ -4,9 +4,21 @@ namespace Baselinker\Api\Request;
 
 use Baselinker\Api\Client;
 use Baselinker\Api\Response\Response;
+use Baselinker\Config;
+use GuzzleHttp\ClientInterface;
 
 class Orders extends Client implements OrdersInterface
 {
+ 
+    /**
+     * @param \Baselinker\Config $config
+     * @param \GuzzleHttp\ClientInterface|null $client
+     */
+    public function __construct(Config $config, ?ClientInterface $client = null)
+    {
+        parent::__construct($config, $client);
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/Api/Request/ProductCatalog.php
+++ b/src/Api/Request/ProductCatalog.php
@@ -4,9 +4,21 @@ namespace Baselinker\Api\Request;
 
 use Baselinker\Api\Client;
 use Baselinker\Api\Response\Response;
+use Baselinker\Config;
+use GuzzleHttp\ClientInterface;
 
 class ProductCatalog extends Client implements ProductCatalogInterface
 {
+ 
+    /**
+     * @param \Baselinker\Config $config
+     * @param \GuzzleHttp\ClientInterface|null $client
+     */
+    public function __construct(Config $config, ?ClientInterface $client = null)
+    {
+        parent::__construct($config, $client);
+    }
+
     /**
      * @inheritDoc
      */

--- a/src/Baselinker.php
+++ b/src/Baselinker.php
@@ -14,6 +14,7 @@ use Baselinker\Api\Request\Orders;
 use Baselinker\Api\Request\OrdersInterface;
 use Baselinker\Api\Request\ProductCatalog;
 use Baselinker\Api\Request\ProductCatalogInterface;
+use GuzzleHttp\ClientInterface;
 
 class Baselinker implements BaselinkerInterface
 {
@@ -23,11 +24,18 @@ class Baselinker implements BaselinkerInterface
     private $config;
 
     /**
-     * @param array $parameters
+     * @var \GuzzleHttp\ClientInterface
      */
-    public function __construct(array $parameters)
+    private $client;
+
+    /**
+     * @param array $parameters
+     * @param \GuzzleHttp\ClientInterface|null $client
+     */
+    public function __construct(array $parameters, ?ClientInterface $client = null)
     {
         $this->config = new Config($parameters);
+        $this->client = $client;
     }
 
     /**


### PR DESCRIPTION
Wprowadziłem minimalne zmiany do repo by móc łatwo testować paczkę przez ustalanie spodziewanej odpowiedzi zwracanej przez Baselinkera, bez jego faktycznego odpytywania.

Przykład testu:
```php
      $mock = new \GuzzleHttp\Handler\MockHandler([
          new \GuzzleHttp\Psr7\Response(200, [], json_encode([
            'status' => 'SUCCESS',
            'orders' => [
                [
                    'order_id' => 1,
                    'order_status_id' => 123,
                ],
            ],
        ]))
      ]);

      $handlerStack = \GuzzleHttp\HandlerStack::create($mock);
      $client = new \GuzzleHttp\Client(['handler' => $handlerStack]);

      $baselinker = \Baselinker\Baselinker(['token' => 'test_token'], $client);
      $orders = $this->baselinker->orders()->getOrders([
            'date_from' => \Carbon\Carbon::parse('-1 month')->timestamp,
      ]);
      
      $this->assertEquals(1, $orders[0]->order_id);
      $this->assertEquals(123, $orders[0]->order_status_id);
```